### PR TITLE
Zero dose constraint/Projection masking for 2D targets

### DIFF
--- a/src/CALOptimize.m
+++ b/src/CALOptimize.m
@@ -29,7 +29,9 @@ classdef CALOptimize
             obj.default_proj.angles = linspace(0,179,180);  
             obj.default_proj.bit8 = 0;  
             obj.default_proj.equalize8bit = 0;  
-            
+            obj.default_proj.zero_constraint = false;
+            obj.default_proj.proj_mask = false;
+
             obj = obj.parseParams(opt_params,proj_params);
             
             obj.target_obj = target_obj;
@@ -38,8 +40,15 @@ classdef CALOptimize
             
             obj.verbose = verbose;
             
+            
+            if obj.proj_params.zero_constraint == true
+                % run image segmentation flood fill routine
+                [obj.proj_params.zero_constraint,~] = getFills(target_obj.target);
+            end
             obj.A = CALProjectorConstructor(target_obj,obj.proj_params,obj.opt_params.parallel);
             
+
+
             obj.thresholds = zeros(1,opt_params.max_iter);
             obj.error = zeros(1,opt_params.max_iter);
         end
@@ -86,6 +95,12 @@ classdef CALOptimize
             end
             if ~isfield(proj_params,'equalize8bit')
                 obj.proj_params.equalize8bit = obj.default_proj.equalize8bit;
+            end
+            if ~isfield(proj_params,'zero_constraint')
+                obj.proj_params.zero_constraint = obj.default_proj.zero_constraint;
+            end
+            if ~isfield(proj_params,'proj_mask')
+                obj.proj_params.proj_mask = obj.default_proj.proj_mask;
             end
         end
         

--- a/src/Examples/ex2Dzeroconstraint.m
+++ b/src/Examples/ex2Dzeroconstraint.m
@@ -1,0 +1,36 @@
+cd ..;
+addpath('Examples')
+
+clear all
+close all
+
+% set projection parameters
+proj_params.angles = linspace(0,179,180);
+proj_params.zero_constraint = true;
+% proj_params.bit8 = 0;
+
+
+% set optimization parameters
+opt_params.max_iter = 25;
+opt_params.threshold = 0.85;
+opt_params.learning_rate = 0.1;
+% opt_params.filter = false;
+
+verbose = 1;
+
+
+% create an example 2D target
+target_2D = createTarget(201,'tube',2);
+
+% prepare the target
+target_obj = CALPrepTarget([],[],verbose,target_2D);
+
+% instantiate the optimization class
+Opt = CALOptimize(target_obj,opt_params,proj_params,verbose);
+
+% run the optimization
+[proj_obj,recon_obj,Opt] = Opt.run();
+
+
+
+cd 'Examples';

--- a/src/Examples/ex2Dzeroconstraint.m
+++ b/src/Examples/ex2Dzeroconstraint.m
@@ -7,14 +7,12 @@ close all
 % set projection parameters
 proj_params.angles = linspace(0,179,180);
 proj_params.zero_constraint = true;
-% proj_params.bit8 = 0;
-
+proj_params.bit8 = 1;
 
 % set optimization parameters
-opt_params.max_iter = 25;
+opt_params.max_iter = 100;
 opt_params.threshold = 0.85;
-opt_params.learning_rate = 0.1;
-% opt_params.filter = false;
+opt_params.learning_rate = 0.002;
 
 verbose = 1;
 

--- a/src/Projector2D.m
+++ b/src/Projector2D.m
@@ -7,9 +7,20 @@ classdef Projector2D
     methods
         function obj = Projector2D(proj_params)
             obj.proj_params = proj_params;
-
+            
+            if ~isscalar(obj.proj_params.zero_constraint)
+                obj.proj_params.proj_mask = obj.getProjMask(obj.proj_params.zero_constraint);
+            end
         end
         
+        function [b] = getProjMask(obj,fills)
+            x = fills;
+            [nT,~] = size(x);
+
+            tmp_b = radon(x, obj.proj_params.angles);
+            tmp_b([1:size(tmp_b,1)/2-nT/2, size(tmp_b,1)/2+nT/2+1:end],:) = [];
+            b = logical(tmp_b);
+        end
         
         function [b] = forward(obj,target)
             x = target;
@@ -18,10 +29,17 @@ classdef Projector2D
             tmp_b = radon(x, obj.proj_params.angles);
             tmp_b([1:size(tmp_b,1)/2-nT/2, size(tmp_b,1)/2+nT/2+1:end],:) = [];
             b = tmp_b;
+            
+            if ~isscalar(obj.proj_params.zero_constraint)
+                b(obj.proj_params.proj_mask) = 0;
+            end
         end
         
         function [x] = backward(obj,proj)
             b = proj;
+            if ~isscalar(obj.proj_params.zero_constraint)
+                b(obj.proj_params.proj_mask) = 0;
+            end
             [nT,~] = size(b);
 
             x = iradon(b, obj.proj_params.angles, 'none',nT);

--- a/src/createTarget.m
+++ b/src/createTarget.m
@@ -15,6 +15,19 @@ elseif strcmp(type,'L')
     target(n_pixels/4:0.5827*n_pixels,n_pixels/4:0.5827*n_pixels) = 1;
     target(n_pixels/4:n_pixels/2,n_pixels/4:n_pixels/2) = 0;
     target(n_pixels/4:0.416*n_pixels,n_pixels/4:0.416*n_pixels) = 1;
+    
+elseif strcmp(type,'tube')
+    target = zeros(n_pixels,n_pixels);
+    [X,Y] = meshgrid(linspace(-1,1,n_pixels),linspace(-1,1,n_pixels));
+    
+    R = sqrt(Y.^2 + X.^2);
+    R1 = sqrt(Y.^2 + (X+1/3).^2);
+    R2 = sqrt(Y.^2 + (X-1/3).^2);
+    target(R<=2/3) = 1;
+    target(R1<=1/5) = 0;
+    target(R2<=1/5) = 0;
+
+    
 elseif strcmp(type,'dots')
     target = zeros(n_pixels,n_pixels);
     

--- a/src/createTarget.m
+++ b/src/createTarget.m
@@ -21,13 +21,21 @@ elseif strcmp(type,'tube')
     [X,Y] = meshgrid(linspace(-1,1,n_pixels),linspace(-1,1,n_pixels));
     
     R = sqrt(Y.^2 + X.^2);
+
+    target(R<=2/3) = 1;
+    target(R<=1/3) = 0;
+
+elseif strcmp(type,'channels')
+    target = zeros(n_pixels,n_pixels);
+    [X,Y] = meshgrid(linspace(-1,1,n_pixels),linspace(-1,1,n_pixels));
+    
+    R = sqrt(Y.^2 + X.^2);
     R1 = sqrt(Y.^2 + (X+1/3).^2);
     R2 = sqrt(Y.^2 + (X-1/3).^2);
     target(R<=2/3) = 1;
-    target(R1<=1/5) = 0;
-    target(R2<=1/5) = 0;
+    target(R1<=1/6) = 0;
+    target(R2<=1/6) = 0;
 
-    
 elseif strcmp(type,'dots')
     target = zeros(n_pixels,n_pixels);
     

--- a/src/util/getFills.m
+++ b/src/util/getFills.m
@@ -1,0 +1,21 @@
+function [fills,fill_inds] = getFills(target)
+
+    figure(100);
+    imagesc(target);
+    colormap('gray')
+    title('Select fill locations, then press enter')
+    axis('off')
+    daspect([1,1,1]);
+    
+    [x,y] = getpts;
+    close(figure(100));
+    
+    x = round(x);
+    y = round(y);
+    fill_inds = [y,x];
+    
+    filled_target = imfill(logical(target),fill_inds);
+
+    fills = xor(logical(target),filled_target);
+
+end


### PR DESCRIPTION
This feature allows the user to specify a region where the reconstruction dose should be identically zero. This equates to clamping the regions in projection space to zero. The user can specify that masking is desired or specify the region directly in object space.

### Specifying desire to apply a zero dose constraint:
At the beginning of optimization, a figure showing the target and the prompt "Select fill locations, then press enter" appears. The user should use their mouse to select **inside** regions where the zero dose constraint should be applied. Then the code will autofill the regions, which means **they must be inside closed boundaries**. 
```matlab
proj_params.zero_constraint = true;
```


### Specifying zero constraint region directly:
The zero constraint region should be a 2D logical matrix where elements that should remain at zero are equal to 1 or true
```matlab
proj_params.zero_constraint = 
logical([0, 0, 0;
      0, 1, 0;
      0, 0, 0;]);
```

